### PR TITLE
Add jsdoc devdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-text-replace": "^0.4.0",
     "handlebars": "^4.0.6",
     "istanbul": "^0.4.5",
+    "jsdoc": "^3.4.3",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "protoplast": "^2.0.0-alpha.23",


### PR DESCRIPTION
Building with grunt failed on my machine since I didn't have jsdoc installed globally. Adding it to the dependencies fixes it for me.