### PR TITLE
Fix `snippets` not loading from config.json in CLI client

### DIFF
--- a/js/core/model/settings.js
+++ b/js/core/model/settings.js
@@ -7,7 +7,10 @@ define(function(require) {
     // TODO: Rename Settings properties to CamelCase (+++)
     var Settings = Protoplast.Model.extend({
 
-        snippets: null,
+        snippets: {
+            name: 'snippets',
+            value: {}
+        },
 
         // Parser settings
 


### PR DESCRIPTION
The last version does not populate the `snippets` property of the settings, thus not replacing these variables in the script. This PR changes the `snippets` property to be properly populated by the `fromJSON` method.

This feature is documented in https://github.com/ifrost/afterwriting-labs/blob/master/docs/clients.md#snippets for the CLI client. The [client.fountain](https://github.com/ifrost/afterwriting-labs/blob/master/test/data/screenplays/client.fountain) script works as intended again after applying this patch.

This regression was introduced between release `v1.2.28` and `v1.3.0`, somewhere between 98ed12f and 
955ebe3.