### PR TITLE
requirejs/text: use npm instead of github dependency

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -24,7 +24,7 @@
             acceptance: '../test/acceptance',
             'aw-parser': '../node_modules/aw-parser/dist/aw-parser.amd',
             'aw-liner': '../node_modules/aw-liner/dist/aw-liner.amd',
-            text: '../node_modules/text/text',
+            text: '../node_modules/requirejs-text/text',
             Blob: 'libs/Blob'
         },
         shim: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5228,8 +5228,12 @@
     "requirejs": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
-      "dev": true
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
+    },
+    "requirejs-text": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/requirejs-text/-/requirejs-text-2.0.15.tgz",
+      "integrity": "sha1-ExOHM2E/xEV7fhJH6Mt1HfeqVCk="
     },
     "requizzle": {
       "version": "0.2.3",
@@ -6679,10 +6683,6 @@
       "requires": {
         "execa": "^0.7.0"
       }
-    },
-    "text": {
-      "version": "github:requirejs/text#3f9d4c19b3a1a3c6f35650c5788cbea1db93197a",
-      "from": "github:requirejs/text"
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "lodash": "^4.17.20",
     "pdfkit": "^0.11.0",
     "protoplast": "2.0.3",
+    "requirejs-text": "^2.0.15",
     "snyk": "^1.319.0",
-    "stdio": "^0.2.7",
-    "text": "github:requirejs/text"
+    "stdio": "^0.2.7"
   },
   "snyk": true
 }


### PR DESCRIPTION
fixes #136 