### PR TITLE
[Feature] Custom Print Profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ local/
 coverage/
 .idea/
 changes.log
+yarn.lock
+.vscode/launch.json

--- a/New folder/sample_profile.yml
+++ b/New folder/sample_profile.yml
@@ -1,0 +1,7 @@
+name: test_profile
+default_max: 30
+base: a4
+paper_size: letter
+lines_per_page: 10
+page_width: 4
+page_height: 8  

--- a/awc.js
+++ b/awc.js
@@ -10,7 +10,7 @@ require.config({
     map: {
         'modernizr': {}
     },
-    use_node_require: ['jquery', 'fs', 'd3', 'pdfkit', 'aw-parser', 'protoplast', 'lodash']
+    use_node_require: ['path', 'jquery', 'fs', 'd3', 'pdfkit', 'aw-parser', 'protoplast', 'lodash', 'yamljs']
 });
 
 var Bootstrap = require('bootstrap');

--- a/js/core/model/settings.js
+++ b/js/core/model/settings.js
@@ -3,6 +3,9 @@ define(function(require) {
     var _ = require('lodash'),
         Protoplast = require('protoplast'),
         fontLoaders = require('fonts/font-loaders'),
+        PrintProfileUtil = require('utils/print-profile-util'),
+        fs = require("fs"),
+        path = require("path"),
         print_profiles = require('utils/print-profiles');
 
     // TODO: Decouple plugin-specific settings (+++)
@@ -231,7 +234,23 @@ define(function(require) {
 
         print: {
             get: function() {
-                var tmpRatio = fontLoaders[this.font_family] && fontLoaders[this.font_family].config["tmp-ratio"];
+                var tmpRatio = fontLoaders[this.font_family] && fontLoaders[this.font_family].config["tmp-ratio"];                            
+                var profileName;
+
+                // Load the profile file if it doesn't exist already
+                this.print_profile = this.print_profile.replace(/[",']/g, "");
+                profileName = path.basename(this.print_profile);
+
+                if (!print_profiles[profileName]) {
+                    var prf = PrintProfileUtil.loadProfile(this.print_profile);                    
+                    
+                    fs.copyFileSync(this.print_profile, 
+                        'print-profiles/' + profileName                
+                    );
+
+                    print_profiles[this.print_profile] = prf;
+                }
+
                 var printProfile = print_profiles[this.print_profile];
                 if (tmpRatio) {
                     printProfile = _.cloneDeep(print_profiles[this.print_profile]);

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@
     var config = require.config({
         baseUrl: 'js',
         paths: {
+            print_profiles: '/print-profiles',
             samples: '../samples/compiled',
             templates: '../templates',
             test_screenplays: '../test/data/test_screenplays',
@@ -25,7 +26,8 @@
             'aw-parser': '../node_modules/aw-parser/dist/aw-parser.amd',
             'aw-liner': '../node_modules/aw-liner/dist/aw-liner.amd',
             text: '../node_modules/requirejs-text/text',
-            Blob: 'libs/Blob'
+            Blob: 'libs/Blob',
+            yamljs: '../node_modules/yamljs/yaml.min'
         },
         shim: {
             handlebars: {

--- a/js/utils/print-profile-util.js
+++ b/js/utils/print-profile-util.js
@@ -1,9 +1,70 @@
 define(function(require) {
 
     var _ = require('lodash'),
+        fs = require('fs'),
+        YAML = require('yamljs'),
         Protoplast = require('protoplast');
 
     var PrintProfileUtil = Protoplast.extend({
+        loadProfile: function(profileLocation) {
+            var rawData = fs.readFileSync(profileLocation, 'utf8');
+            var matchMaxRgx = /default_max:\s*([&A-Za-z]*)\s*(\d+)/;
+            var matchBaseRgx = /base:\s*[",']?([A-Za-z0-9]*)[",']?/;
+
+            var matchBase = rawData.match(matchBaseRgx);
+            var base = null;
+            var baseData = {};
+            
+            if(matchBase != null && matchBase.length > 1) {
+                // get contents of base file
+                base = fs.readFileSync('print-profiles/' + matchBase[1] + '.yml', 'utf8');
+                // replace default_max in base file with the new file                
+                var baseDefMax = base.match(matchMaxRgx);
+                var srcDefMax = rawData.match(matchMaxRgx);
+                if (baseDefMax)   {
+                    var newString = "default_max: " + 
+                    (baseDefMax[1] != null && baseDefMax[1] == null ? "" : baseDefMax[1]) +
+                    " " + 
+                    srcDefMax[2];
+                    
+                    base = base.replace(baseDefMax[0], newString);
+                    
+                }
+
+                baseData = YAML.parse(base);
+                profileData = Object.assign(baseData, YAML.parse(rawData));
+            } else { 
+                profileData = YAML.parse(rawData);
+            }                                    
+    
+            return profileData;
+        },
+        /**
+         * 
+         * @param {number} defaultMax 
+         * @param {object} source 
+         * @param {NULL|object} base 
+         * @returns {object}
+         */
+        loadFiles: function() {
+            var dir = 'print-profiles';
+            var result = {};
+            try {
+                var files = fs.readdirSync(dir, { withFileTypes: true });
+                var $vm = this;                            
+                files.forEach(function(file) {
+                    if (file.isFile() && file.name.indexOf('.yml')) {
+                        var profile = $vm.loadProfile(dir + "/" + file.name);
+                        result[profile.name] = profile;                        
+                    }
+                });
+            
+            } catch (err) {
+                console.log(err);
+            }
+
+            return result;
+        },
 
         /**
          * Create new profile based on a given sourceProfile and change the font size

--- a/js/utils/print-profiles.js
+++ b/js/utils/print-profiles.js
@@ -1,105 +1,18 @@
-define(function(require) {
+define(function(require) {    
 
     var browser = require('utils/browser'),
-        PrintProfileUtil = require('utils/print-profile-util');
+        PrintProfileUtil = require('utils/print-profile-util');            
 
-    var A4_DEFAULT_MAX = 58,
-        US_DEFAULT_MAX = 61;
-
-    var print_profiles = {
-        "a4": {
-            paper_size: "a4",
-            font_size: 12,
-            lines_per_page: 57,
-            top_margin: 1.0,
-            page_width: 8.27,
-            page_height: 11.7,
-            left_margin: 1.5,
-            right_margin: 1,
-            font_width: 0.1,
-            font_height: 0.1667,
-            line_spacing: 1,
-            page_number_top_margin: 0.5,
-            dual_max_factor: 0.75,
-            title_page: {
-                top_start: 3.5,
-                left_side: ['notes', 'copyright'],
-                right_side: ['draft date', 'date', 'contact']
-            },
-            scene_heading: {
-                feed: 1.5,
-                max: A4_DEFAULT_MAX
-            },
-            action: {
-                feed: 1.5,
-                max: A4_DEFAULT_MAX
-            },
-            shot: {
-                feed: 1.5,
-                max: A4_DEFAULT_MAX
-            },
-            character: {
-                feed: 3.5,
-                max: 33
-            },
-            parenthetical: {
-                feed: 3,
-                max: 26
-            },
-            dialogue: {
-                feed: 2.5,
-                max: 36
-            },
-            transition: {
-                feed: 0.0,
-                max: A4_DEFAULT_MAX
-            },
-            centered: {
-                feed: 1.5,
-                style: 'center',
-                max: A4_DEFAULT_MAX
-            },
-            synopsis: {
-                feed: 0.5,
-                max: A4_DEFAULT_MAX,
-                italic: true,
-                color: '#888888',
-                padding: 0,
-                feed_with_last_section: true
-            },
-            section: {
-                feed: 0.5,
-                max: A4_DEFAULT_MAX,
-                color: '#555555',
-                level_indent: 0.2
-            },
-            note: {
-                color: '#888888',
-                italic: true
-            }
-        }
-    };
-
-    print_profiles.usletter = JSON.parse(JSON.stringify(print_profiles.a4));
-    var letter = print_profiles.usletter;
-    letter.paper_size = 'letter';
-    letter.lines_per_page = 55;
-    letter.page_width = 8.5;
-    letter.page_height = 11;
-
-    letter.scene_heading.max = US_DEFAULT_MAX;
-    letter.action.max = US_DEFAULT_MAX;
-    letter.shot.max = US_DEFAULT_MAX;
-    letter.transition.max = US_DEFAULT_MAX;
-    letter.section.max = US_DEFAULT_MAX;
-    letter.synopsis.max = US_DEFAULT_MAX;
+    var print_profiles = PrintProfileUtil.loadFiles();
 
     // font size = experimental feature
     var url_params = browser.url_params();
     if (url_params.fontSize) {
         var fontSize = parseInt(url_params.fontSize, 10);
-        print_profiles.usletter = PrintProfileUtil.withNewFontSize(print_profiles.usletter, fontSize);
-        print_profiles.a4 = PrintProfileUtil.withNewFontSize(print_profiles.a4, fontSize);
+        Object.keys(print_profiles, function(profile) {
+            var prf = print_profiles[profile];
+            print_profiles[profile] = ProcessingInstruction.withNewFontSize(prf, fontSize);
+        });      
     }
 
     return print_profiles;

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "pdfkit": "^0.11.0",
     "protoplast": "2.0.3",
     "requirejs-text": "^2.0.15",
-    "stdio": "^0.2.7"
+    "stdio": "^0.2.7",
+    "yamljs": "^0.3.0"
   },
   "snyk": true
 }

--- a/print-profiles/a4.yml
+++ b/print-profiles/a4.yml
@@ -1,0 +1,76 @@
+name: a4
+default_max: &max 61
+paper_size: a4
+font_size: 12
+lines_per_page: 57
+top_margin: 1.0
+page_width: 8.27
+page_height: 11.7
+left_margin: 1.5
+right_margin: 1
+font_width: 0.1
+font_height: 0.1667
+line_spacing: 1
+page_number_top_margin: 0.5
+dual_max_factor: 0.75
+
+title_page: 
+    top_start: 3.5
+    left_side:
+      - notes
+      - copyright
+    right_side:
+      - draft date
+      - date
+      - contact    
+
+scene_heading: 
+    feed: 1.5
+    max: *max
+
+action: 
+    feed: 1.5
+    max: *max
+
+shot: 
+    feed: 1.5
+    max: *max
+
+character: 
+    feed: 3.5
+    max: 33
+
+parenthetical: 
+    feed: 3
+    max: 26
+
+dialogue: 
+    feed: 2.5
+    max: 36
+
+transition: 
+    feed: 0.0
+    max: *max
+
+centered: 
+    feed: 1.5
+    style: 'center'
+    max: *max
+
+synopsis: 
+    feed: 0.5
+    max: *max
+    italic: true
+    color: '#888888'
+    padding: 0
+    feed_with_last_section: true
+
+section: 
+    feed: 0.5
+    max: *max
+    color: '#555555'
+    level_indent: 0.2
+
+note: 
+    color: '#888888'
+    italic: true

--- a/print-profiles/letter.yml
+++ b/print-profiles/letter.yml
@@ -1,0 +1,7 @@
+name: usletter
+default_max: 58
+base: a4
+paper_size: letter
+lines_per_page: 55
+page_width: 8.5
+page_height: 11  

--- a/print-profiles/sample_profile_full.yml
+++ b/print-profiles/sample_profile_full.yml
@@ -1,0 +1,116 @@
+# [Required] name: the internal name of this profile
+name: a4
+# default_max: a variable you can use in the template to specify the default max value for properties
+# &max will define the variable name as "max", 61 is the value
+# you can override this when using base and it will slug it into wherever the variable is used
+# to use the variable: prop_name: *max
+default_max: &max 61
+# paper_size: the dimensions of the paper, accepts values [a4, usletter]
+paper_size: a4
+# font_size: font size in pts at 72 dpi
+font_size: 12
+# lines_per_page: maximum lines on a page
+lines_per_page: 57
+# top_margin: top margin in inches
+top_margin: 1.0
+# page_width: the width of the content area of the page in inches
+page_width: 8.27
+# page_height: the height of the content area of the page in inches
+page_height: 11.7
+# left_margin: the default left margin for the page in inches
+left_margin: 1.5
+# right_margin: the default right margin for the page in inches
+right_margin: 1
+# font_width: the width of each character in inches
+font_width: 0.1
+# font_height: the height of each character in inches
+font_height: 0.1667
+# line_spacing: the spacing of the lines in count (1, 1.5, 2, etc.)
+line_spacing: 1
+# page_number_top_margin: the top margin of the page number in inches
+page_number_top_margin: 0.5
+# dual_max_factor: ??
+dual_max_factor: 0.75
+
+# === What follows is title page and line type specific ===
+
+# title_page
+title_page: 
+    # top margin in inches
+    top_start: 3.5
+    # left and right anchored fields.
+    # values: [notes, copyright, draft date, date, contact]
+    left_side:
+      - notes
+      - copyright
+    right_side:
+      - draft date
+      - date
+      - contact    
+
+# ===== For the line types the following properties are availabe =====
+# == Page Composition
+# feed: [float] the amount of space in inches from the edge of the page to the text start
+# feed_with_last_section: [bool] 
+# max: [float] the maximum number of characters on a line (multiplied by font size) 
+# level_indent [int] Only available to synopsis & section
+#     sets the indentation level for subsequent lines.
+# == Presentation
+# style: apply alignment [left, right, center]
+# italic: make this line italic
+# bold: make this line bold
+# underline: make this line underlined
+# override_color: override the normal color with this
+# color: the font color
+# padding: the padding around these lines
+# =====
+scene_heading: 
+    feed: 1.5
+    max: *max
+
+action: 
+    feed: 1.5
+    max: *max
+
+shot: 
+    feed: 1.5
+    max: *max
+
+character: 
+    feed: 3.5
+    max: 33
+
+parenthetical: 
+    feed: 3
+    max: 26
+
+dialogue: 
+    feed: 2.5
+    max: 36
+
+transition: 
+    feed: 0.0
+    max: *max
+
+centered: 
+    feed: 1.5
+    style: 'center'
+    max: *max
+
+synopsis: 
+    feed: 0.5
+    max: *max
+    italic: true
+    color: '#888888'
+    padding: 0
+    feed_with_last_section: true
+
+section: 
+    feed: 0.5
+    max: *max
+    color: '#555555'
+    level_indent: 0.2
+
+note: 
+    color: '#888888'
+    italic: true


### PR DESCRIPTION
- Added the ability to use a custom YAML file as a print profile for the CLI (fallback to a4)
- Copy custom files to print-profiles directory first time for future use by name
- Converted the existing print profiles to YAML files and extracted from code
- Added some sample print profiles with comments on format

This should solve issue #125 as well as allowing the user to set up custom profiles for easy submission styling.